### PR TITLE
Escape output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,8 @@ runs:
       if: steps.plan.outcome == 'success'
       shell: bash
       run: |
-        echo "::set-output name=result::$(terraform show tfplan)"
+        PLAN_RESULT=$(terraform show tfplan)
+        echo "::set-output name=result::${PLAN_RESULT//$'\n'/\\n}"
         terraform show -json tfplan | jq -c '.resource_changes' > tfplan.resource_changes.json
         # Ref: https://www.terraform.io/docs/internals/json-format.html#change-representation
         RESOURCES_TO_BE_REPLACED=$(jq -c '. | map(select(.change.actions | length==2) ) | [.[].address]' < tfplan.resource_changes.json)


### PR DESCRIPTION
## What
Escape `\n`.

## Why
To output multiline strings, `\n` must be escaped.

https://github.community/t/set-output-truncates-multiline-strings/16852

## How

## Ref
